### PR TITLE
 Add comprehensive test suite to cover core extraction, scoring, and APIs  #11

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+# conftest.py

--- a/tests/test_api_clients.py
+++ b/tests/test_api_clients.py
@@ -1,0 +1,98 @@
+import pytest
+import responses
+import base64
+from phish_extractor import query_virustotal_url, query_abuseipdb, ThreatIntelResult
+
+@responses.activate
+def test_virustotal_get_mocked_200(monkeypatch):
+    monkeypatch.setattr('phish_extractor.VT_API_KEY', 'dummy_key')
+    
+    url = "http://evil.com"
+    url_id = base64.urlsafe_b64encode(url.encode()).decode().rstrip("=")
+    endpoint = f"https://www.virustotal.com/api/v3/urls/{url_id}"
+    
+    responses.add(
+        responses.GET,
+        endpoint,
+        json={"data": {"attributes": {"last_analysis_stats": {"malicious": 8, "undetected": 10}}}},
+        status=200
+    )
+    
+    result = query_virustotal_url(url)
+    assert result.malicious is True
+    assert result.detection_ratio == "8/18"
+
+@responses.activate
+def test_virustotal_get_mocked_401(monkeypatch):
+    monkeypatch.setattr('phish_extractor.VT_API_KEY', 'dummy_key')
+    
+    url = "http://evil.com"
+    url_id = base64.urlsafe_b64encode(url.encode()).decode().rstrip("=")
+    endpoint = f"https://www.virustotal.com/api/v3/urls/{url_id}"
+    
+    responses.add(responses.GET, endpoint, status=401)
+    
+    result = query_virustotal_url(url)
+    assert result.error == "Invalid API key (HTTP 401)"
+
+@responses.activate
+def test_virustotal_get_mocked_429(monkeypatch):
+    monkeypatch.setattr('phish_extractor.VT_API_KEY', 'dummy_key')
+    
+    url = "http://evil.com"
+    url_id = base64.urlsafe_b64encode(url.encode()).decode().rstrip("=")
+    endpoint = f"https://www.virustotal.com/api/v3/urls/{url_id}"
+    
+    responses.add(responses.GET, endpoint, status=429)
+    
+    result = query_virustotal_url(url)
+    assert result.error == "Rate-limited (HTTP 429) — retry later"
+
+@responses.activate
+def test_virustotal_get_mocked_404(monkeypatch):
+    monkeypatch.setattr('phish_extractor.VT_API_KEY', 'dummy_key')
+    
+    url = "http://evil.com"
+    url_id = base64.urlsafe_b64encode(url.encode()).decode().rstrip("=")
+    endpoint = f"https://www.virustotal.com/api/v3/urls/{url_id}"
+    
+    responses.add(responses.GET, endpoint, status=404)
+    
+    result = query_virustotal_url(url)
+    assert result.error == "Not found in VirusTotal database"
+
+@responses.activate
+def test_query_abuseipdb_malicious(monkeypatch):
+    monkeypatch.setattr('phish_extractor.ABUSEIPDB_API_KEY', 'dummy_key')
+    
+    ip = "1.2.3.4"
+    endpoint = f"https://api.abuseipdb.com/api/v2/check"
+    
+    responses.add(
+        responses.GET,
+        endpoint,
+        json={"data": {"abuseConfidenceScore": 75}},
+        status=200
+    )
+    
+    result = query_abuseipdb(ip)
+    assert result.malicious is True
+    assert result.abuse_confidence == 75
+
+@responses.activate
+def test_query_abuseipdb_benign(monkeypatch):
+    monkeypatch.setattr('phish_extractor.ABUSEIPDB_API_KEY', 'dummy_key')
+    
+    ip = "5.6.7.8"
+    endpoint = f"https://api.abuseipdb.com/api/v2/check"
+    
+    responses.add(
+        responses.GET,
+        endpoint,
+        json={"data": {"abuseConfidenceScore": 74}},
+        status=200
+    )
+    
+    result = query_abuseipdb(ip)
+    assert result.malicious is False
+    assert result.abuse_confidence == 74

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,35 @@
+import hashlib
+from email.message import EmailMessage
+from phish_extractor import extract_attachments
+
+def test_extract_attachments():
+    msg = EmailMessage()
+    msg['Subject'] = 'Test with attachment'
+    
+    # Add a text part
+    msg.set_content('Please see the attached file')
+    
+    # Add an attachment
+    payload_bytes = b'malicious payload here'
+    msg.add_attachment(payload_bytes, maintype='application', subtype='octet-stream', filename='evil.exe')
+    
+    attachments = extract_attachments(msg)
+    
+    assert len(attachments) == 1
+    assert attachments[0].filename == 'evil.exe'
+    assert attachments[0].content_type == 'application/octet-stream'
+    assert attachments[0].size_bytes == len(payload_bytes)
+    assert attachments[0].sha256 == hashlib.sha256(payload_bytes).hexdigest()
+
+def test_extract_attachments_no_filename():
+    msg = EmailMessage()
+    msg['Subject'] = 'Test with nameless attachment'
+    
+    msg.set_content('Please see the attached file')
+    payload_bytes = b'test'
+    msg.add_attachment(payload_bytes, maintype='application', subtype='octet-stream')
+    
+    attachments = extract_attachments(msg)
+    
+    assert len(attachments) == 1
+    assert attachments[0].filename == 'unnamed_attachment'

--- a/tests/test_defang.py
+++ b/tests/test_defang.py
@@ -12,7 +12,7 @@ def test_defang_domain():
 
 def test_defang_ip():
     assert defang_ip("8.8.8.8") == "8[.]8[.]8[.]8"
-    assert defang_ip("2001:db8::1") == "2001:db8::1" # IPv6 has no dots, should remain unchanged if no dots
+    assert defang_ip("2001:db8::1") == "2001:db8::1" # IPv6 without dots remains unchanged
     
     # But if mapped ipv4
     assert defang_ip("::ffff:192.168.1.1") == "::ffff:192[.]168[.]1[.]1"

--- a/tests/test_defang.py
+++ b/tests/test_defang.py
@@ -1,0 +1,18 @@
+import pytest
+from phish_extractor import defang_url, defang_domain, defang_ip
+
+def test_defang_url():
+    assert defang_url("http://evil.com/path.html") == "hxxp://evil[.]com/path.html"
+    assert defang_url("https://malicious.co.uk/x.php") == "hxxps://malicious[.]co[.]uk/x.php"
+    assert defang_url("https://1.2.3.4/abc") == "hxxps://1[.]2[.]3[.]4/abc"
+
+def test_defang_domain():
+    assert defang_domain("evil.com") == "evil[.]com"
+    assert defang_domain("malicious.co.uk") == "malicious[.]co[.]uk"
+
+def test_defang_ip():
+    assert defang_ip("8.8.8.8") == "8[.]8[.]8[.]8"
+    assert defang_ip("2001:db8::1") == "2001:db8::1" # IPv6 has no dots, should remain unchanged if no dots
+    
+    # But if mapped ipv4
+    assert defang_ip("::ffff:192.168.1.1") == "::ffff:192[.]168[.]1[.]1"

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,14 @@
+import pytest
+from phish_extractor import _extract_auth_result
+
+def test_extract_auth_result():
+    auth_header = "spf=pass (sender IP is 1.2.3.4); dkim=fail (bad signature); dmarc=softfail action=none;"
+    
+    assert _extract_auth_result(auth_header, "spf") == "pass"
+    assert _extract_auth_result(auth_header, "dkim") == "fail"
+    assert _extract_auth_result(auth_header, "dmarc") == "softfail"
+    
+def test_extract_auth_result_not_found():
+    auth_header = "spf=pass (sender IP is 1.2.3.4);"
+    
+    assert _extract_auth_result(auth_header, "dkim") == "not found"

--- a/tests/test_ioc.py
+++ b/tests/test_ioc.py
@@ -1,0 +1,29 @@
+import pytest
+from phish_extractor import extract_iocs
+
+def test_extract_iocs():
+    text = """
+    Check out this link: https://evil.com/login?id=123
+    Another one: http://phish.net/x
+    Here is a domain: malicious-domain.co.uk
+    Internal IP: http://10.0.0.1/ and 192.168.1.1
+    Public IP: 8.8.8.8
+    And an IPv6 address: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+    """
+    
+    iocs = extract_iocs(text)
+    
+    assert "https://evil.com/login?id=123" in iocs.urls
+    assert "http://phish.net/x" in iocs.urls
+    
+    # URL domains should be excluded from `domains` list
+    assert "evil.com" not in iocs.domains
+    assert "phish.net" not in iocs.domains
+    
+    assert "malicious-domain.co.uk" in iocs.domains
+    
+    assert "8.8.8.8" in iocs.ipv4_addresses
+    assert "10.0.0.1" not in iocs.ipv4_addresses
+    assert "192.168.1.1" not in iocs.ipv4_addresses
+    
+    assert "2001:0db8:85a3:0000:0000:8a2e:0370:7334" in iocs.ipv6_addresses

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,9 @@
+import pytest
+from phish_extractor import safe_md
+
+def test_safe_md():
+    assert safe_md("Hello|World") == "Hello&#124;World"
+    assert safe_md("Hello\nWorld") == "Hello World"
+    assert safe_md("Hello\rWorld") == "HelloWorld"
+    assert safe_md(None) == "None"
+    assert safe_md("Normal string") == "Normal string"

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,28 @@
+import pytest
+from phish_extractor import calculate_risk, EmailHeaders, ThreatIntelResult
+
+def test_calculate_risk_low():
+    headers = EmailHeaders(spf_result="pass", dkim_result="pass", dmarc_result="pass")
+    intel = []
+    assert calculate_risk(headers, intel) == "LOW"
+
+def test_calculate_risk_medium():
+    headers = EmailHeaders(spf_result="fail", dkim_result="pass", dmarc_result="pass")
+    intel = [ThreatIntelResult(ioc="x", source="x", error="timeout")]
+    # score = 2 (spf fail) + 1 (error) = 3 -> MEDIUM
+    assert calculate_risk(headers, intel) == "MEDIUM"
+
+def test_calculate_risk_high():
+    headers = EmailHeaders(spf_result="fail", dkim_result="fail", dmarc_result="fail")
+    intel = []
+    # score = 6 -> HIGH
+    assert calculate_risk(headers, intel) == "HIGH"
+
+def test_calculate_risk_critical():
+    headers = EmailHeaders(spf_result="fail", dkim_result="fail", dmarc_result="fail")
+    intel = [
+        ThreatIntelResult(ioc="1.1.1.1", source="AbuseIPDB", malicious=True),
+        ThreatIntelResult(ioc="evil.com", source="VirusTotal", malicious=True)
+    ]
+    # score = 6 + 3 + 3 = 12 -> CRITICAL
+    assert calculate_risk(headers, intel) == "CRITICAL"

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -9,13 +9,13 @@ def test_calculate_risk_low():
 def test_calculate_risk_medium():
     headers = EmailHeaders(spf_result="fail", dkim_result="pass", dmarc_result="pass")
     intel = [ThreatIntelResult(ioc="x", source="x", error="timeout")]
-    # score = 2 (spf fail) + 1 (error) = 3 -> MEDIUM
+    # Reaches MEDIUM risk threshold
     assert calculate_risk(headers, intel) == "MEDIUM"
 
 def test_calculate_risk_high():
     headers = EmailHeaders(spf_result="fail", dkim_result="fail", dmarc_result="fail")
     intel = []
-    # score = 6 -> HIGH
+    # Reaches HIGH risk threshold
     assert calculate_risk(headers, intel) == "HIGH"
 
 def test_calculate_risk_critical():
@@ -24,5 +24,5 @@ def test_calculate_risk_critical():
         ThreatIntelResult(ioc="1.1.1.1", source="AbuseIPDB", malicious=True),
         ThreatIntelResult(ioc="evil.com", source="VirusTotal", malicious=True)
     ]
-    # score = 6 + 3 + 3 = 12 -> CRITICAL
+    # Reaches CRITICAL risk threshold
     assert calculate_risk(headers, intel) == "CRITICAL"


### PR DESCRIPTION
#11 While looking at your codebase, I realized that we didn't have a foundational test suite set up for phish_extractor. Without it, any future tweaks to our regex patterns, defanging logic, or risk scoring could easily introduce silent regressions unless we manually ran the script against a live .eml file every time.

To fix this and make the project easier to maintain, I’ve introduced pytest and built out our baseline test coverage.

Here is exactly what I did:

- Project Structure: I set up a tests/ directory with a standard modular structure (including an empty conftest.py for future shared fixtures).

- IOC & Defanging: I wrote tests to ensure extract_iocs() correctly parses URLs, domains, and both IPv4/IPv6 addresses, while properly filtering out private/internal IPs. I also verified that our defang_* functions correctly neutralize links and IPs.

- Header & Attachment Parsing: Added coverage for  _extract_auth_result()  to ensure we accurately flag SPF/DKIM/DMARC passes and fails. I also tested extract_attachments() to verify it reliably grabs filenames and computes accurate SHA-256 hashes without needing to write files to disk.

- Mocked Threat Intel APIs: I brought in the responses library so I could safely mock our external calls to VirusTotal and AbuseIPDB. I made sure we're correctly handling 200 OKs, authentication errors (401), rate limits (429), and not-found (404) scenarios, and validated that our >= 75 confidence threshold for AbuseIPDB works as intended.

- Risk Scoring & Reporting: Finally, I added tests for our calculate_risk()  tiers to make sure all four levels (LOW to CRITICAL) map correctly, and checked safe_md() to prevent any odd table-breaking markdown injection in the final report.


Everything is currently passing locally via 'PYTHONPATH=. pytest tests/'. 


Let me know if you'd like me to add any additional edge cases!