### PR TITLE
docs: add .env.example comments, gitignore reports/, and secrets management guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,15 @@
+# VirusTotal — https://www.virustotal.com/gui/my-apikey
 VT_API_KEY=your_virustotal_api_key_here
+
+# AbuseIPDB — https://www.abuseipdb.com/account/api
 ABUSEIPDB_API_KEY=your_abuseipdb_api_key_here
+
+# Optional tuning
+MAX_EML_SIZE_MB=50
+MIN_ATTACHMENT_BYTES=256
+```
+
+**2 — Update `.gitignore`** — add after `*.msg`:
+```
+# Build artifacts and reports
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ env/
 # Except for explicit mock files in samples/
 !samples/*.eml
 !samples/*.msg
+
+# Build artifacts and reports
+reports/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,23 @@ Copy the example environment file and fill in your keys:
 ```powershell
 copy .env.example .env
 ```
-Open `.env` in your editor and securely add your VirusTotal and AbuseIPDB API keys.
+
+> ⚠️ **Never commit your `.env` file.** It is listed in `.gitignore` to prevent accidental exposure.
+> If you accidentally push secrets, **rotate your API keys immediately** via the VirusTotal and AbuseIPDB dashboards — treat any exposed key as compromised.
+
+---
+
+## 🔒 Secrets Management
+
+- `.env` is excluded from version control via `.gitignore` — never remove this rule.
+- In CI/CD pipelines, use **GitHub Actions Secrets** (or your vault of choice) instead of `.env` files.
+- To proactively prevent secret leaks, consider adding a `pre-commit` hook using [`detect-secrets`](https://github.com/Yelp/detect-secrets) or [`gitleaks`](https://github.com/gitleaks/gitleaks):
+```bash
+pip install detect-secrets
+detect-secrets scan > .secrets.baseline
+```
+
+- If you ever accidentally commit a real API key, rotate it immediately — assume it is compromised.
 
 ---
 


### PR DESCRIPTION
Closes #15

Improves secrets hygiene documentation and configuration files.

## Changes

### `.env.example`
- Added inline comments with links to API key dashboards for VirusTotal and AbuseIPDB
- Added optional tuning variables: `MAX_EML_SIZE_MB` and `MIN_ATTACHMENT_BYTES`

### `.gitignore`
- Added `reports/` to prevent generated reports from being accidentally committed

### `README.md`
- Added warning block after the `copy .env.example .env` step reminding users never to commit `.env` and to rotate keys immediately if accidentally exposed
- Added new `🔒 Secrets Management` section covering:
  - `.gitignore` protection
  - GitHub Actions Secrets for CI/CD
  - `pre-commit` hooks with `detect-secrets` or `gitleaks`
  - Key rotation guidance if secrets are ever exposed