### PR TITLE
Fix #9: Sanitize attachment filenames to prevent path traversal

### DIFF
--- a/phish_extractor.py
+++ b/phish_extractor.py
@@ -516,7 +516,7 @@ def extract_attachments(msg: EmailMessage) -> list[AttachmentInfo]:
         if disposition not in ("attachment", "inline"):
             continue
 
-        filename: str = part.get_filename() or "unnamed_attachment"
+        filename: str = sanitize_attachment_filename(part.get_filename())
         content_type: str = part.get_content_type()
 
         raw_payload: Any = part.get_payload(decode=True)
@@ -551,6 +551,18 @@ def extract_attachments(msg: EmailMessage) -> list[AttachmentInfo]:
         )
 
     return attachments
+
+
+def sanitize_attachment_filename(filename: str | None) -> str:
+    """Return a safe display filename without path traversal components."""
+    if not filename:
+        return "unnamed_attachment"
+
+    cleaned = re.sub(r"[\x00-\x1f\x7f]", "_", str(filename)).strip()
+    cleaned = re.split(r"[\\/]", cleaned)[-1]
+    if not cleaned or cleaned in {".", ".."}:
+        return "unnamed_attachment"
+    return cleaned[:255]
 
 
 # ===================================================================

--- a/tests/test_phish_extractor.py
+++ b/tests/test_phish_extractor.py
@@ -41,6 +41,20 @@ class TestPhishExtractor(unittest.TestCase):
         self.assertTrue(len(attach) > 0)
         self.assertEqual(attach[0].filename, "Invoice_78291.pdf")
 
+    def test_attachment_filename_is_sanitized(self):
+        self.assertEqual(
+            phish_extractor.sanitize_attachment_filename("../../dropper.exe"),
+            "dropper.exe",
+        )
+        self.assertEqual(
+            phish_extractor.sanitize_attachment_filename(r"C:\Users\Public\dropper.exe"),
+            "dropper.exe",
+        )
+        self.assertEqual(
+            phish_extractor.sanitize_attachment_filename(r"..\payload.exe"),
+            "payload.exe",
+        )
+
     @patch("phish_extractor.query_virustotal_url")
     @patch("phish_extractor.query_abuseipdb")
     def test_threat_intel_mock(self, mock_abuse, mock_vt):


### PR DESCRIPTION
## Description
Sanitizes raw attachment filenames extracted from email MIME headers to strip path traversal sequences (`..`), directory separators (`/`, `\`), and control characters before processing or reporting.

Fixes #9