### PR TITLE
Fix #4: Redact API keys from logging output

### DIFF
--- a/phish_extractor.py
+++ b/phish_extractor.py
@@ -89,6 +89,22 @@ HTTP_TIMEOUT_SECONDS: int = 15
 MAX_EML_SIZE_MB: int = _positive_int_env("MAX_EML_SIZE_MB", 25)
 MAX_EML_SIZE_BYTES: int = MAX_EML_SIZE_MB * 1024 * 1024
 
+
+class SecretRedactionFilter(logging.Filter):
+    """Redact configured API keys from every log record."""
+
+    def __init__(self, secrets: list[str | None]) -> None:
+        super().__init__()
+        self._secrets = tuple(secret for secret in secrets if secret)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        for secret in self._secrets:
+            message = message.replace(secret, "[REDACTED]")
+        record.msg = message
+        record.args = ()
+        return True
+
 # ---------------------------------------------------------------------------
 # Logging setup
 # ---------------------------------------------------------------------------
@@ -98,6 +114,10 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
 log: logging.Logger = logging.getLogger("phish_extractor")
+_redaction_filter = SecretRedactionFilter([VT_API_KEY, ABUSEIPDB_API_KEY])
+for _handler in logging.getLogger().handlers:
+    _handler.addFilter(_redaction_filter)
+log.addFilter(_redaction_filter)
 
 # ---------------------------------------------------------------------------
 # Regex patterns for IOC extraction

--- a/tests/test_phish_extractor.py
+++ b/tests/test_phish_extractor.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import tempfile
@@ -65,6 +66,22 @@ class TestPhishExtractor(unittest.TestCase):
             ):
                 with self.assertRaisesRegex(ValueError, "size limit"):
                     phish_extractor.parse_eml(Path(eml_file.name))
+
+    def test_secret_redaction_filter(self):
+        redactor = phish_extractor.SecretRedactionFilter(["vt-secret", "abuse-secret"])
+        record = logging.LogRecord(
+            name="test",
+            level=logging.DEBUG,
+            pathname=__file__,
+            lineno=1,
+            msg="headers=%s key=%s",
+            args=("vt-secret", "abuse-secret"),
+            exc_info=None,
+        )
+        redactor.filter(record)
+        self.assertNotIn("vt-secret", record.getMessage())
+        self.assertNotIn("abuse-secret", record.getMessage())
+        self.assertEqual(record.getMessage(), "headers=[REDACTED] key=[REDACTED]")
 
     @patch("phish_extractor.query_virustotal_url")
     @patch("phish_extractor.query_abuseipdb")


### PR DESCRIPTION
## Description
Adds a custom `SecretRedactionFilter` to logger handlers that dynamically redacts configured API keys (`VT_API_KEY`, `ABUSEIPDB_API_KEY`) from log records to prevent secret leakage in debug/verbose logs.

Fixes #4